### PR TITLE
Use didUpdateWidget to set selectedIndex when rebuilding

### DIFF
--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -73,7 +73,9 @@ class _GNavState extends State<GNav> {
   @override
   void didUpdateWidget(GNav oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if(widget.selectedIndex != oldWidget.selectedIndex) selectedIndex = widget.selectedIndex;
+    if(widget.selectedIndex != oldWidget.selectedIndex) {
+        selectedIndex = widget.selectedIndex;
+    }
   }
 
   @override

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -71,6 +71,12 @@ class _GNavState extends State<GNav> {
   }
 
   @override
+  void didUpdateWidget(GNav oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if(widget.selectedIndex != oldWidget.selectedIndex) selectedIndex = widget.selectedIndex;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Container(
         color: widget.backgroundColor,

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -74,7 +74,7 @@ class _GNavState extends State<GNav> {
   void didUpdateWidget(GNav oldWidget) {
     super.didUpdateWidget(oldWidget);
     if(widget.selectedIndex != oldWidget.selectedIndex) {
-        selectedIndex = widget.selectedIndex;
+      selectedIndex = widget.selectedIndex;
     }
   }
 


### PR DESCRIPTION
This fixes #48 by utilizing `didUpdateWidget` and setting `selectedIndex` to the new value if it has changed.