### PR TITLE
A new type of Bottom Nav Bar added which is a bit similar to old one but looks awsome, however the old Nav Bar is still there.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_nav_bar/google_nav_bar.dart';
+import 'package:line_icons/line_icons.dart';
 
 void main() => runApp(MaterialApp(
     builder: (context, child) {
@@ -18,8 +19,7 @@ class Example extends StatefulWidget {
 
 class _ExampleState extends State<Example> {
   int _selectedIndex = 0;
-  static const TextStyle optionStyle =
-      TextStyle(fontSize: 30, fontWeight: FontWeight.w600);
+  static const TextStyle optionStyle = TextStyle(fontSize: 30, fontWeight: FontWeight.w600);
   static const List<Widget> _widgetOptions = <Widget>[
     Text(
       'Home',
@@ -74,19 +74,19 @@ class _ExampleState extends State<Example> {
               tabBackgroundColor: Colors.grey[100]!,
               tabs: [
                 GButton(
-                  icon: Icons.home,
+                  icon: LineIcons.home,
                   text: 'Home',
                 ),
                 GButton(
-                  icon: Icons.favorite,
+                  icon: LineIcons.heart_o,
                   text: 'Likes',
                 ),
                 GButton(
-                  icon: Icons.search,
+                  icon: LineIcons.search,
                   text: 'Search',
                 ),
                 GButton(
-                  icon: Icons.person,
+                  icon: LineIcons.user,
                   text: 'Profile',
                 ),
               ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,7 +19,8 @@ class Example extends StatefulWidget {
 
 class _ExampleState extends State<Example> {
   int _selectedIndex = 0;
-  static const TextStyle optionStyle = TextStyle(fontSize: 30, fontWeight: FontWeight.w600);
+  static const TextStyle optionStyle =
+      TextStyle(fontSize: 30, fontWeight: FontWeight.w600);
   static const List<Widget> _widgetOptions = <Widget>[
     Text(
       'Home',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:google_nav_bar/google_nav_bar.dart';
-import 'package:line_icons/line_icons.dart';
 
 void main() => runApp(MaterialApp(
     builder: (context, child) {
@@ -19,7 +18,8 @@ class Example extends StatefulWidget {
 
 class _ExampleState extends State<Example> {
   int _selectedIndex = 0;
-  static const TextStyle optionStyle = TextStyle(fontSize: 30, fontWeight: FontWeight.w600);
+  static const TextStyle optionStyle =
+      TextStyle(fontSize: 30, fontWeight: FontWeight.w600);
   static const List<Widget> _widgetOptions = <Widget>[
     Text(
       'Home',
@@ -74,19 +74,19 @@ class _ExampleState extends State<Example> {
               tabBackgroundColor: Colors.grey[100]!,
               tabs: [
                 GButton(
-                  icon: LineIcons.home,
+                  icon: Icons.home,
                   text: 'Home',
                 ),
                 GButton(
-                  icon: LineIcons.heart_o,
+                  icon: Icons.favorite,
                   text: 'Likes',
                 ),
                 GButton(
-                  icon: LineIcons.search,
+                  icon: Icons.search,
                   text: 'Search',
                 ),
                 GButton(
-                  icon: LineIcons.user,
+                  icon: Icons.person,
                   text: 'Profile',
                 ),
               ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,7 +78,7 @@ class _ExampleState extends State<Example> {
                   text: 'Home',
                 ),
                 GButton(
-                  icon: LineIcons.heart_o,
+                  icon: LineIcons.heart,
                   text: 'Likes',
                 ),
                 GButton(

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -129,50 +129,46 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
             ),
             child: FittedBox(
               fit: BoxFit.fitHeight,
-              child: Column(children: [
-                Column(
-                  //mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    icon,
-                    Container(
-                      child: widget.text,
-                      // child: Container(
-                      //   child: Align(
-                      //       //alignment: Alignment.centerRight,
-                      //       widthFactor: curveValue,
-                      //       child: Container(
-                      //         child: Opacity(
-                      //             opacity: _expanded
-                      //                 ? pow(expandController.value, 13)
-                      //                     as double
-                      //                 : expandController
-                      //                     .drive(
-                      //                         CurveTween(curve: Curves.easeIn))
-                      //                     .value,
-                      //             child: Padding(
-                      //               padding: EdgeInsets.only(
-                      //                   bottom: widget.gap! +
-                      //                       8 -
-                      //                       (8 *
-                      //                           expandController
-                      //                               .drive(CurveTween(
-                      //                                   curve:
-                      //                                       Curves.easeOutSine))
-                      //                               .value),
-                      //                   right: 8 *
-                      //                       expandController
-                      //                           .drive(CurveTween(
-                      //                               curve: Curves.easeOutSine))
-                      //                           .value),
-                      //               child: widget.text,
-                      //             )),
-                      //       )),
-                      // ),
+              child: Stack(children: [
+                Row(mainAxisAlignment: MainAxisAlignment.end, children: [
+                  Opacity(
+                    opacity: 0,
+                    child: icon,
+                  ),
+                  Container(
+                    child: Container(
+                      child: Align(
+                          alignment: Alignment.centerRight,
+                          widthFactor: curveValue,
+                          child: Container(
+                            child: Opacity(
+                                opacity: _expanded
+                                    ? pow(expandController.value, 13) as double
+                                    : expandController
+                                        .drive(CurveTween(curve: Curves.easeIn))
+                                        .value,
+                                child: Padding(
+                                  padding: EdgeInsets.only(
+                                      left: widget.gap! +
+                                          8 -
+                                          (8 *
+                                              expandController
+                                                  .drive(CurveTween(
+                                                      curve:
+                                                          Curves.easeOutSine))
+                                                  .value),
+                                      right: 8 *
+                                          expandController
+                                              .drive(CurveTween(
+                                                  curve: Curves.easeOutSine))
+                                              .value),
+                                  child: widget.text,
+                                )),
+                          )),
                     ),
-                  ],
-                ),
-
-                //Align(alignment: Alignment.centerLeft, child: icon),
+                  ),
+                ]),
+                Align(alignment: Alignment.centerLeft, child: icon),
               ]),
             ),
           ),

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -133,47 +133,45 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
                 Column(
                   //mainAxisAlignment: MainAxisAlignment.end,
                   children: [
-                    Opacity(
-                      opacity: 0,
-                      child: icon,
-                    ),
+                    icon,
                     Container(
-                      child: Container(
-                        child: Align(
-                            //alignment: Alignment.centerRight,
-                            widthFactor: curveValue,
-                            child: Container(
-                              child: Opacity(
-                                  opacity: _expanded
-                                      ? pow(expandController.value, 13)
-                                          as double
-                                      : expandController
-                                          .drive(
-                                              CurveTween(curve: Curves.easeIn))
-                                          .value,
-                                  child: Padding(
-                                    padding: EdgeInsets.only(
-                                        bottom: widget.gap! +
-                                            8 -
-                                            (8 *
-                                                expandController
-                                                    .drive(CurveTween(
-                                                        curve:
-                                                            Curves.easeOutSine))
-                                                    .value),
-                                        right: 8 *
-                                            expandController
-                                                .drive(CurveTween(
-                                                    curve: Curves.easeOutSine))
-                                                .value),
-                                    child: widget.text,
-                                  )),
-                            )),
-                      ),
+                      child: widget.text,
+                      // child: Container(
+                      //   child: Align(
+                      //       //alignment: Alignment.centerRight,
+                      //       widthFactor: curveValue,
+                      //       child: Container(
+                      //         child: Opacity(
+                      //             opacity: _expanded
+                      //                 ? pow(expandController.value, 13)
+                      //                     as double
+                      //                 : expandController
+                      //                     .drive(
+                      //                         CurveTween(curve: Curves.easeIn))
+                      //                     .value,
+                      //             child: Padding(
+                      //               padding: EdgeInsets.only(
+                      //                   bottom: widget.gap! +
+                      //                       8 -
+                      //                       (8 *
+                      //                           expandController
+                      //                               .drive(CurveTween(
+                      //                                   curve:
+                      //                                       Curves.easeOutSine))
+                      //                               .value),
+                      //                   right: 8 *
+                      //                       expandController
+                      //                           .drive(CurveTween(
+                      //                               curve: Curves.easeOutSine))
+                      //                           .value),
+                      //               child: widget.text,
+                      //             )),
+                      //       )),
+                      // ),
                     ),
                   ],
                 ),
-                icon,
+
                 //Align(alignment: Alignment.centerLeft, child: icon),
               ]),
             ),

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -28,7 +28,7 @@ class Button extends StatefulWidget {
     this.border,
     this.activeBorder,
     this.shadow,
-    this.gNavType = GNavType.defaultType,
+    this.style = Style.defaultType,
     this.textSize,
   }) : super(key: key);
 
@@ -54,7 +54,7 @@ class Button extends StatefulWidget {
   final Border? border;
   final Border? activeBorder;
   final List<BoxShadow>? shadow;
-  final GNavType gNavType;
+  final Style? style;
   final double? textSize;
 
   @override
@@ -136,7 +136,7 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
               fit: BoxFit.fitHeight,
               child: Builder(
                 builder: (_) {
-                  if (widget.gNavType == GNavType.defaultType) {
+                  if (widget.style == Style.defaultType) {
                     return Stack(
                       children: [
                         Row(
@@ -185,7 +185,7 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
                         Align(alignment: Alignment.centerLeft, child: icon),
                       ],
                     );
-                  } else if (widget.gNavType == GNavType.customType1) {
+                  } else if (widget.style == Style.oldSchool) {
                     return Column(
                       children: [
                         icon,

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -134,7 +134,7 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     Opacity(
-                      opacity: 0,
+                      opacity: 10,
                       child: icon,
                     ),
                     Container(

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -130,44 +130,49 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
             child: FittedBox(
               fit: BoxFit.fitHeight,
               child: Stack(children: [
-                Row(mainAxisAlignment: MainAxisAlignment.end, children: [
-                  Opacity(
-                    opacity: 0,
-                    child: icon,
-                  ),
-                  Container(
-                    child: Container(
-                      child: Align(
-                          alignment: Alignment.centerRight,
-                          widthFactor: curveValue,
-                          child: Container(
-                            child: Opacity(
-                                opacity: _expanded
-                                    ? pow(expandController.value, 13) as double
-                                    : expandController
-                                        .drive(CurveTween(curve: Curves.easeIn))
-                                        .value,
-                                child: Padding(
-                                  padding: EdgeInsets.only(
-                                      left: widget.gap! +
-                                          8 -
-                                          (8 *
-                                              expandController
-                                                  .drive(CurveTween(
-                                                      curve:
-                                                          Curves.easeOutSine))
-                                                  .value),
-                                      right: 8 *
-                                          expandController
-                                              .drive(CurveTween(
-                                                  curve: Curves.easeOutSine))
-                                              .value),
-                                  child: widget.text,
-                                )),
-                          )),
+                Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Opacity(
+                      opacity: 0,
+                      child: icon,
                     ),
-                  ),
-                ]),
+                    Container(
+                      child: Container(
+                        child: Align(
+                            alignment: Alignment.centerRight,
+                            widthFactor: curveValue,
+                            child: Container(
+                              child: Opacity(
+                                  opacity: _expanded
+                                      ? pow(expandController.value, 13)
+                                          as double
+                                      : expandController
+                                          .drive(
+                                              CurveTween(curve: Curves.easeIn))
+                                          .value,
+                                  child: Padding(
+                                    padding: EdgeInsets.only(
+                                        bottom: widget.gap! +
+                                            8 -
+                                            (8 *
+                                                expandController
+                                                    .drive(CurveTween(
+                                                        curve:
+                                                            Curves.easeOutSine))
+                                                    .value),
+                                        right: 8 *
+                                            expandController
+                                                .drive(CurveTween(
+                                                    curve: Curves.easeOutSine))
+                                                .value),
+                                    child: widget.text,
+                                  )),
+                            )),
+                      ),
+                    ),
+                  ],
+                ),
                 Align(alignment: Alignment.centerLeft, child: icon),
               ]),
             ),

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -129,18 +129,18 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
             ),
             child: FittedBox(
               fit: BoxFit.fitHeight,
-              child: Stack(children: [
+              child: Column(children: [
                 Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
+                  //mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     Opacity(
-                      opacity: 1.0,
+                      opacity: 0,
                       child: icon,
                     ),
                     Container(
                       child: Container(
                         child: Align(
-                            alignment: Alignment.centerRight,
+                            //alignment: Alignment.centerRight,
                             widthFactor: curveValue,
                             child: Container(
                               child: Opacity(
@@ -173,7 +173,8 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
                     ),
                   ],
                 ),
-                Align(alignment: Alignment.centerLeft, child: icon),
+                icon,
+                //Align(alignment: Alignment.centerLeft, child: icon),
               ]),
             ),
           ),

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -28,7 +28,7 @@ class Button extends StatefulWidget {
     this.border,
     this.activeBorder,
     this.shadow,
-    this.style = Style.google,
+    this.style = GnavStyle.google,
     this.textSize,
   }) : super(key: key);
 
@@ -54,7 +54,7 @@ class Button extends StatefulWidget {
   final Border? border;
   final Border? activeBorder;
   final List<BoxShadow>? shadow;
-  final Style? style;
+  final GnavStyle? style;
   final double? textSize;
 
   @override
@@ -136,7 +136,7 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
               fit: BoxFit.fitHeight,
               child: Builder(
                 builder: (_) {
-                  if (widget.style == Style.google) {
+                  if (widget.style == GnavStyle.google) {
                     return Stack(
                       children: [
                         Row(
@@ -185,7 +185,7 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
                         Align(alignment: Alignment.centerLeft, child: icon),
                       ],
                     );
-                  } else if (widget.style == Style.oldSchool) {
+                  } else if (widget.style == GnavStyle.oldSchool) {
                     return Column(
                       children: [
                         icon,

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -1,6 +1,7 @@
 import 'dart:math' show pow;
 
 import 'package:flutter/material.dart';
+import 'package:google_nav_bar/google_nav_bar.dart';
 
 class Button extends StatefulWidget {
   const Button({
@@ -27,6 +28,8 @@ class Button extends StatefulWidget {
     this.border,
     this.activeBorder,
     this.shadow,
+    this.gNavType = GNavType.defaultType,
+    this.textSize,
   }) : super(key: key);
 
   final IconData? icon;
@@ -51,6 +54,8 @@ class Button extends StatefulWidget {
   final Border? border;
   final Border? activeBorder;
   final List<BoxShadow>? shadow;
+  final GNavType gNavType;
+  final double? textSize;
 
   @override
   _ButtonState createState() => _ButtonState();
@@ -129,47 +134,78 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
             ),
             child: FittedBox(
               fit: BoxFit.fitHeight,
-              child: Stack(children: [
-                Row(mainAxisAlignment: MainAxisAlignment.end, children: [
-                  Opacity(
-                    opacity: 0,
-                    child: icon,
-                  ),
-                  Container(
-                    child: Container(
-                      child: Align(
-                          alignment: Alignment.centerRight,
-                          widthFactor: curveValue,
-                          child: Container(
-                            child: Opacity(
-                                opacity: _expanded
-                                    ? pow(expandController.value, 13) as double
-                                    : expandController
-                                        .drive(CurveTween(curve: Curves.easeIn))
-                                        .value,
-                                child: Padding(
-                                  padding: EdgeInsets.only(
-                                      left: widget.gap! +
-                                          8 -
-                                          (8 *
-                                              expandController
-                                                  .drive(CurveTween(
-                                                      curve:
-                                                          Curves.easeOutSine))
-                                                  .value),
-                                      right: 8 *
-                                          expandController
-                                              .drive(CurveTween(
-                                                  curve: Curves.easeOutSine))
-                                              .value),
-                                  child: widget.text,
-                                )),
-                          )),
-                    ),
-                  ),
-                ]),
-                Align(alignment: Alignment.centerLeft, child: icon),
-              ]),
+              child: Builder(
+                builder: (_) {
+                  if (widget.gNavType == GNavType.defaultType) {
+                    return Stack(
+                      children: [
+                        Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              Opacity(
+                                opacity: 0,
+                                child: icon,
+                              ),
+                              Container(
+                                child: Container(
+                                  child: Align(
+                                      alignment: Alignment.centerRight,
+                                      widthFactor: curveValue,
+                                      child: Container(
+                                        child: Opacity(
+                                            opacity: _expanded
+                                                ? pow(expandController.value,
+                                                    13) as double
+                                                : expandController
+                                                    .drive(CurveTween(
+                                                        curve: Curves.easeIn))
+                                                    .value,
+                                            child: Padding(
+                                              padding: EdgeInsets.only(
+                                                  left: widget.gap! +
+                                                      8 -
+                                                      (8 *
+                                                          expandController
+                                                              .drive(CurveTween(
+                                                                  curve: Curves
+                                                                      .easeOutSine))
+                                                              .value),
+                                                  right: 8 *
+                                                      expandController
+                                                          .drive(CurveTween(
+                                                              curve: Curves
+                                                                  .easeOutSine))
+                                                          .value),
+                                              child: widget.text,
+                                            )),
+                                      )),
+                                ),
+                              ),
+                            ]),
+                        Align(alignment: Alignment.centerLeft, child: icon),
+                      ],
+                    );
+                  } else if (widget.gNavType == GNavType.customType1) {
+                    return Column(
+                      children: [
+                        icon,
+                        Container(
+                          padding: EdgeInsets.only(top: widget.gap!),
+                          child: Text(
+                            widget.text!.data!,
+                            style: TextStyle(
+                              color: _colorTweenAnimation.value,
+                              fontSize: widget.textSize ?? 16,
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  } else {
+                    return Container();
+                  }
+                },
+              ),
             ),
           ),
         ),

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -28,7 +28,7 @@ class Button extends StatefulWidget {
     this.border,
     this.activeBorder,
     this.shadow,
-    this.style = Style.defaultType,
+    this.style = Style.google,
     this.textSize,
   }) : super(key: key);
 
@@ -136,7 +136,7 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
               fit: BoxFit.fitHeight,
               child: Builder(
                 builder: (_) {
-                  if (widget.style == Style.defaultType) {
+                  if (widget.style == Style.google) {
                     return Stack(
                       children: [
                         Row(

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -134,7 +134,7 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     Opacity(
-                      opacity: 10,
+                      opacity: 1.0,
                       child: icon,
                     ),
                     Container(

--- a/lib/src/gbutton.dart
+++ b/lib/src/gbutton.dart
@@ -31,7 +31,7 @@ class GButton extends StatefulWidget {
   final Border? activeBorder;
   final List<BoxShadow>? shadow;
   final String? semanticLabel;
-  final Style? style;
+  final GnavStyle? style;
   final double? textSize;
 
   const GButton({
@@ -62,7 +62,7 @@ class GButton extends StatefulWidget {
     this.activeBorder,
     this.shadow,
     this.semanticLabel,
-    this.style = Style.google,
+    this.style = GnavStyle.google,
     this.textSize,
   }) : super(key: key);
 

--- a/lib/src/gbutton.dart
+++ b/lib/src/gbutton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show HapticFeedback;
+import 'package:google_nav_bar/google_nav_bar.dart';
 
 import 'button.dart';
 
@@ -30,6 +31,8 @@ class GButton extends StatefulWidget {
   final Border? activeBorder;
   final List<BoxShadow>? shadow;
   final String? semanticLabel;
+  final GNavType gNavType;
+  final double? textSize;
 
   const GButton({
     Key? key,
@@ -59,6 +62,8 @@ class GButton extends StatefulWidget {
     this.activeBorder,
     this.shadow,
     this.semanticLabel,
+    this.gNavType = GNavType.defaultType,
+    this.textSize,
   }) : super(key: key);
 
   @override
@@ -71,6 +76,8 @@ class _GButtonState extends State<GButton> {
     return Semantics(
       label: widget.semanticLabel ?? widget.text,
       child: Button(
+        textSize: widget.textSize,
+        gNavType: widget.gNavType,
         borderRadius: widget.borderRadius,
         border: widget.border,
         activeBorder: widget.activeBorder,

--- a/lib/src/gbutton.dart
+++ b/lib/src/gbutton.dart
@@ -31,7 +31,7 @@ class GButton extends StatefulWidget {
   final Border? activeBorder;
   final List<BoxShadow>? shadow;
   final String? semanticLabel;
-  final GNavType gNavType;
+  final Style? style;
   final double? textSize;
 
   const GButton({
@@ -62,7 +62,7 @@ class GButton extends StatefulWidget {
     this.activeBorder,
     this.shadow,
     this.semanticLabel,
-    this.gNavType = GNavType.defaultType,
+    this.style = Style.defaultType,
     this.textSize,
   }) : super(key: key);
 
@@ -77,7 +77,7 @@ class _GButtonState extends State<GButton> {
       label: widget.semanticLabel ?? widget.text,
       child: Button(
         textSize: widget.textSize,
-        gNavType: widget.gNavType,
+        style: widget.style,
         borderRadius: widget.borderRadius,
         border: widget.border,
         activeBorder: widget.activeBorder,

--- a/lib/src/gbutton.dart
+++ b/lib/src/gbutton.dart
@@ -62,7 +62,7 @@ class GButton extends StatefulWidget {
     this.activeBorder,
     this.shadow,
     this.semanticLabel,
-    this.style = Style.defaultType,
+    this.style = Style.google,
     this.textSize,
   }) : super(key: key);
 

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 
 import 'gbutton.dart';
 
+enum GNavType {
+  defaultType,
+  customType1,
+}
+
 class GNav extends StatefulWidget {
   const GNav({
     Key? key,
@@ -29,6 +34,8 @@ class GNav extends StatefulWidget {
     this.haptic = true,
     this.tabBackgroundGradient,
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
+    this.gNavType = GNavType.defaultType,
+    this.textSize,
   }) : super(key: key);
 
   final List<GButton> tabs;
@@ -55,6 +62,8 @@ class GNav extends StatefulWidget {
   final List<BoxShadow>? tabShadow;
   final Gradient? tabBackgroundGradient;
   final MainAxisAlignment mainAxisAlignment;
+  final GNavType gNavType;
+  final double? textSize;
 
   @override
   _GNavState createState() => _GNavState();
@@ -86,6 +95,8 @@ class _GNavState extends State<GNav> {
             mainAxisAlignment: widget.mainAxisAlignment,
             children: widget.tabs
                 .map((t) => GButton(
+                      textSize: widget.textSize,
+                      gNavType: widget.gNavType,
                       key: t.key,
                       border: t.border ?? widget.tabBorder,
                       activeBorder: t.activeBorder ?? widget.tabActiveBorder,
@@ -111,8 +122,10 @@ class _GNavState extends State<GNav> {
                       haptic: widget.haptic,
                       leading: t.leading,
                       curve: widget.curve,
-                      backgroundGradient: t.backgroundGradient ?? widget.tabBackgroundGradient,
-                      backgroundColor: t.backgroundColor ?? widget.tabBackgroundColor,
+                      backgroundGradient:
+                          t.backgroundGradient ?? widget.tabBackgroundGradient,
+                      backgroundColor:
+                          t.backgroundColor ?? widget.tabBackgroundColor,
                       duration: widget.duration,
                       onPressed: () {
                         if (!clickable) return;

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'gbutton.dart';
 
 enum Style {
-  defaultType,
+  google,
   oldSchool,
 }
 
@@ -34,7 +34,7 @@ class GNav extends StatefulWidget {
     this.haptic = true,
     this.tabBackgroundGradient,
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
-    this.style = Style.defaultType,
+    this.style = Style.google,
     this.textSize,
   }) : super(key: key);
 

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 
 import 'gbutton.dart';
 
-enum GNavType {
+enum Style {
   defaultType,
-  customType1,
+  oldSchool,
 }
 
 class GNav extends StatefulWidget {
@@ -34,7 +34,7 @@ class GNav extends StatefulWidget {
     this.haptic = true,
     this.tabBackgroundGradient,
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
-    this.gNavType = GNavType.defaultType,
+    this.style = Style.defaultType,
     this.textSize,
   }) : super(key: key);
 
@@ -62,7 +62,7 @@ class GNav extends StatefulWidget {
   final List<BoxShadow>? tabShadow;
   final Gradient? tabBackgroundGradient;
   final MainAxisAlignment mainAxisAlignment;
-  final GNavType gNavType;
+  final Style? style;
   final double? textSize;
 
   @override
@@ -96,7 +96,7 @@ class _GNavState extends State<GNav> {
             children: widget.tabs
                 .map((t) => GButton(
                       textSize: widget.textSize,
-                      gNavType: widget.gNavType,
+                      style: widget.style,
                       key: t.key,
                       border: t.border ?? widget.tabBorder,
                       activeBorder: t.activeBorder ?? widget.tabActiveBorder,

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'gbutton.dart';
 
-enum Style {
+enum GnavStyle {
   google,
   oldSchool,
 }
@@ -34,7 +34,7 @@ class GNav extends StatefulWidget {
     this.haptic = true,
     this.tabBackgroundGradient,
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
-    this.style = Style.google,
+    this.style = GnavStyle.google,
     this.textSize,
   }) : super(key: key);
 
@@ -62,7 +62,7 @@ class GNav extends StatefulWidget {
   final List<BoxShadow>? tabShadow;
   final Gradient? tabBackgroundGradient;
   final MainAxisAlignment mainAxisAlignment;
-  final Style? style;
+  final GnavStyle? style;
   final double? textSize;
 
   @override


### PR DESCRIPTION
To use the new Nav bar use a property gNavType in the GNav widget. Setting it to GNavType.defaultType renders the normal Nav bar while using GNavType.customType1 renders a new awsome Nav bar.

The new Nav Bar looks something like this:

![Capture](https://user-images.githubusercontent.com/61021884/116065853-e01e6a80-a6a0-11eb-8a9e-a69e687f21eb.PNG)

Accepting this pull request will not affect the original functionality but it adds more features that a user can decide to have.