### PR TITLE
Make the state class _GNavState public

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   badges:
     dependency: "direct main"
     description:
@@ -28,7 +28,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -94,7 +94,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -155,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -169,7 +176,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=0.2.5"

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -87,14 +87,12 @@ class GNavState extends State<GNav> {
     }
   }
 
-  /// change active tab index; can be used with [PageView].
-  Future<void> animateTo(int index, {int? from}) async {
+  /// change active tab index
+  Future<void> animateTo(int index) async {
     setState(() {
       selectedIndex = index;
       clickable = false;
     });
-
-    //t.onPressed?.call();
 
     widget.onTabChange?.call(selectedIndex);
 

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -66,10 +66,10 @@ class GNav extends StatefulWidget {
   final double? textSize;
 
   @override
-  _GNavState createState() => _GNavState();
+  GNavState createState() => GNavState();
 }
 
-class _GNavState extends State<GNav> {
+class GNavState extends State<GNav> {
   late int selectedIndex;
   bool clickable = true;
 

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -87,6 +87,24 @@ class GNavState extends State<GNav> {
     }
   }
 
+  /// change active tab index; can be used with [PageView].
+  Future<void> animateTo(int index, {int? from}) async {
+    setState(() {
+      selectedIndex = index;
+      clickable = false;
+    });
+
+    //t.onPressed?.call();
+
+    widget.onTabChange?.call(selectedIndex);
+
+    Future.delayed(widget.duration, () {
+      setState(() {
+        clickable = true;
+      });
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -66,7 +66,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -127,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -141,6 +148,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This is a PR of an issue in open a few minutes ago (#77 ) 

This allows me to do the following in my code:

` @override
  Widget build(BuildContext context) {
    final appBarKey = GlobalKey<GNavState>(); // This was not possible with the state being private

    const _kPages = <String, IconData>{
      'Home': Icons.home,
      'Explore': Icons.search,
      'Alerts': Icons.notifications,
      'Leagues': CommunityMaterialIcons.trophy
    };

    return Consumer(
      builder: (context, ref, child) {
        var currentPageIndex = ref.watch(bottomNavigationProvider); //My Navigation Drawer can update this value when a user clicks on a menu item on it

        if (currentPageIndex < _kPages.length) {
          appBarKey.currentState?.animateTo(currentPageIndex); // Now I can animate the bottom navigation drawer to the index which the navigation drawer is also pointing to
        }

        return GNav(
          key: appBarKey,
          tabs: buildGNavButtons(_kPages),
          activeColor: Colors.redAccent,
          gap: 8.0,
          onTabChange: (int i) =>SonicNavigator.navigateToPage(ref, i),
        );
      },
    );
  }
`