### PR TITLE
Added extension, animateTo, clickIndex

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.9.0"
   badges:
     dependency: "direct main"
     description:
@@ -28,28 +28,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -63,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -94,21 +87,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -141,35 +141,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=0.2.5"

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -83,21 +83,9 @@ class _GNavState extends State<GNav> {
   late int selectedIndex;
   bool clickable = true;
 
-  Future<void> animateTo(int index) async {
-    // if (!clickable) return;
+  Future<void> animateTo(int toIndex) async {
     setState(() {
-      selectedIndex = index;
-      clickable = false;
-    });
-
-    widget.tabs[selectedIndex].onPressed?.call();
-
-    widget.onTabChange?.call(selectedIndex);
-
-    await Future.delayed(widget.duration, () {
-      setState(() {
-        clickable = true;
-      });
+      selectedIndex = toIndex;
     });
   }
 

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -83,9 +83,29 @@ class GNavState extends State<GNav> {
   late int selectedIndex;
   bool clickable = true;
 
+  // Animation only
   Future<void> animateTo(int toIndex) async {
     setState(() {
       selectedIndex = toIndex;
+    });
+  }
+
+  // Fire click event
+  Future<void> clickIndex(int toIndex) async {
+    if (!clickable) return;
+    setState(() {
+      selectedIndex = toIndex;
+      clickable = false;
+    });
+
+    widget.tabs[selectedIndex].onPressed?.call();
+
+    widget.onTabChange?.call(selectedIndex);
+
+    Future.delayed(widget.duration, () {
+      setState(() {
+        clickable = true;
+      });
     });
   }
 

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 
 import 'gbutton.dart';
 
+extension GNavContext on BuildContext {
+  /// GNav
+  _GNavState? get gNav => GNav.of(this);
+}
+
 enum GnavStyle {
   google,
   oldSchool,
@@ -67,11 +72,34 @@ class GNav extends StatefulWidget {
 
   @override
   _GNavState createState() => _GNavState();
+
+  /// static function to provide the drawer state
+  static _GNavState? of(BuildContext context) {
+    return context.findAncestorStateOfType<State<GNav>>() as _GNavState?;
+  }
 }
 
 class _GNavState extends State<GNav> {
   late int selectedIndex;
   bool clickable = true;
+
+  Future<void> animateTo(int index) async {
+    if (!clickable) return;
+    setState(() {
+      selectedIndex = index;
+      clickable = false;
+    });
+
+    widget.tabs[selectedIndex].onPressed?.call();
+
+    widget.onTabChange?.call(selectedIndex);
+
+    await Future.delayed(widget.duration, () {
+      setState(() {
+        clickable = true;
+      });
+    });
+  }
 
   @override
   void initState() {

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -84,7 +84,7 @@ class _GNavState extends State<GNav> {
   bool clickable = true;
 
   Future<void> animateTo(int index) async {
-    if (!clickable) return;
+    // if (!clickable) return;
     setState(() {
       selectedIndex = index;
       clickable = false;

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -4,7 +4,7 @@ import 'gbutton.dart';
 
 extension GNavContext on BuildContext {
   /// GNav
-  _GNavState? get gNav => GNav.of(this);
+  GNavState? get gNav => GNav.of(this);
 }
 
 enum GnavStyle {
@@ -71,15 +71,15 @@ class GNav extends StatefulWidget {
   final double? textSize;
 
   @override
-  _GNavState createState() => _GNavState();
+  GNavState createState() => GNavState();
 
   /// static function to provide the drawer state
-  static _GNavState? of(BuildContext context) {
-    return context.findAncestorStateOfType<State<GNav>>() as _GNavState?;
+  static GNavState? of(BuildContext context) {
+    return context.findAncestorStateOfType<State<GNav>>() as GNavState?;
   }
 }
 
-class _GNavState extends State<GNav> {
+class GNavState extends State<GNav> {
   late int selectedIndex;
   bool clickable = true;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +59,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -113,34 +113,27 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"


### PR DESCRIPTION
Similar to https://pub.dev/packages/convex_bottom_bar

I have made 4 useful updates:

1. animteTo which will only change the active index without any firing tab events.
2. clickTo which will fire click event to wanted index similar to a manual click.
3. Made the state public so we can make keys to control the nav bar.
4. Added extensions so now you can do the following:
```
context.gNav?.animateTo(tabsRouter.activeIndex);
context.gNav?.clickIndex(tabsRouter.activeIndex);
```

or through using keys:

```
appBarKey.currentState?.animateTo(tabsRouter.activeIndex),
appBarKey.currentState?.clickIndex(tabsRouter.activeIndex),
```

