### PR TITLE
Fix: Prevent setState() after dispose in delayed callback

### DIFF
--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -139,9 +139,11 @@ class _GNavState extends State<GNav> {
                         widget.onTabChange?.call(selectedIndex);
 
                         Future.delayed(widget.duration, () {
-                          setState(() {
-                            clickable = true;
-                          });
+                          if (context.mounted) {
+                            setState(() {
+                              clickable = true;
+                            });
+                          }
                         });
                       },
                     ))


### PR DESCRIPTION
Fix setState() called after dispose error and prevent app freeze

This PR addresses the FlutterError where setState() was being called after the widget was disposed, which could lead to app freezes. The fix adds a check for context.mounted before calling setState() in the delayed Future callback. This prevents the error from occurring and the associated app freeze when the widget is no longer in the widget tree when the delayed callback executes.