### PR TITLE
Add vertical nav bar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ GNav(
   iconSize: 24, // tab button icon size
   tabBackgroundColor: Colors.purple.withOpacity(0.1), // selected tab background color
   padding: EdgeInsets.symmetric(horizontal: 20, vertical: 5), // navigation bar padding
+  axis: GnavAxis.horizontal // Define the nav bar axis
   tabs: [
     GButton(
       icon: LineIcons.home,

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -7,6 +7,11 @@ enum GnavStyle {
   oldSchool,
 }
 
+enum GnavAxis {
+  horizontal,
+  vertical
+}
+
 class GNav extends StatefulWidget {
   const GNav({
     Key? key,
@@ -36,6 +41,7 @@ class GNav extends StatefulWidget {
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
     this.style = GnavStyle.google,
     this.textSize,
+    this.axis = GnavAxis.horizontal
   }) : super(key: key);
 
   final List<GButton> tabs;
@@ -64,6 +70,7 @@ class GNav extends StatefulWidget {
   final MainAxisAlignment mainAxisAlignment;
   final GnavStyle? style;
   final double? textSize;
+  final GnavAxis? axis;
 
   @override
   _GNavState createState() => _GNavState();
@@ -91,8 +98,9 @@ class _GNavState extends State<GNav> {
   Widget build(BuildContext context) {
     return Container(
         color: widget.backgroundColor,
-        child: Row(
+        child: Flex(
             mainAxisAlignment: widget.mainAxisAlignment,
+            direction: widget.axis == GnavAxis.horizontal ? Axis.horizontal : Axis.vertical,
             children: widget.tabs
                 .map((t) => GButton(
                       textSize: widget.textSize,


### PR DESCRIPTION
## Support for vertical nav bar, solving issue #95 

### Example:

https://github.com/user-attachments/assets/71c63b44-e4a4-48af-a24c-4031a9beb399

### Implementation

For vertical mode, do not use the `bottomNavigationBar`. Instead, place the Gnav inside the body.
Set the axis to vertical by using `GnavAxis.vertical` in the axis property.

### Code Example

```dart

import 'package:flutter/material.dart';
import 'package:google_nav_bar/google_nav_bar.dart';
import 'package:line_icons/line_icons.dart';

void main() => runApp(MaterialApp(
    builder: (context, child) {
      return Directionality(textDirection: TextDirection.ltr, child: child!);
    },
    title: 'GNav',
    theme: ThemeData(
      primaryColor: Colors.grey[800],
    ),
    home: Example()));

class Example extends StatefulWidget {
  @override
  _ExampleState createState() => _ExampleState();
}

class _ExampleState extends State<Example> {
  int _selectedIndex = 0;
  static const TextStyle optionStyle =
      TextStyle(fontSize: 30, fontWeight: FontWeight.w600);
  static const List<Widget> _widgetOptions = <Widget>[
    Text(
      'Home',
      style: optionStyle,
    ),
    Text(
      'Likes',
      style: optionStyle,
    ),
    Text(
      'Search',
      style: optionStyle,
    ),
    Text(
      'Profile',
      style: optionStyle,
    ),
  ];

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      backgroundColor: Colors.white,
      appBar: AppBar(
        elevation: 20,
        title: const Text('GoogleNavBar'),
      ),
      body: Row(
        children: [
          Container(
            decoration: BoxDecoration(
              color: Colors.white,
              boxShadow: [
                BoxShadow(
                  blurRadius: 20,
                  color: Colors.black.withOpacity(.1),
                )
              ],
            ),
            child: SafeArea(
              child: SizedBox(  
                width: 100, // <--- Gnav width                    
                child: Padding(
                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
                  child: GNav(                
                    rippleColor: Colors.grey[300]!,
                    hoverColor: Colors.grey[100]!,
                    gap: 1,
                    activeColor: Colors.black,
                    iconSize: 24,
                    padding: EdgeInsets.symmetric(horizontal: 20, vertical: 12),
                    duration: Duration(milliseconds: 400),
                    tabBackgroundColor: Colors.grey[100]!,
                    color: Colors.black,
                    axis: GnavAxis.vertical, // <--- Define the axis to vertical
                    tabs: [
                      GButton(
                        icon: LineIcons.home,
                        text: 'Home',
                      ),
                      GButton(
                        icon: LineIcons.heart,
                        text: 'Likes',
                      ),
                      GButton(
                        icon: LineIcons.search,
                        text: 'Search',
                      ),
                      GButton(
                        icon: LineIcons.user,
                        text: 'Profile',
                      ),
                    ],
                    selectedIndex: _selectedIndex,
                    onTabChange: (index) {
                      setState(() {
                        _selectedIndex = index;
                      });
                    },
                  ),
                ),
              ),
            ),
          ),

          
          Expanded(
            child: Center(
              child: _widgetOptions.elementAt(_selectedIndex),
            ),
          ),
        ],
      ),
      
      // bottomNavigationBar: ,  <--- Don't use for vertical Nav Bar
    );
  }
}

```

closes #95