### PR TITLE
Customize the selected Gbutton size, solves issue #93

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ GNav(
   iconSize: 24, // tab button icon size
   tabBackgroundColor: Colors.purple.withOpacity(0.1), // selected tab background color
   padding: EdgeInsets.symmetric(horizontal: 20, vertical: 5), // navigation bar padding
+  selectedGbuttonSize: Size(500, 50), // Customize the size of the selected GButton
   tabs: [
     GButton(
       icon: LineIcons.home,

--- a/lib/src/gbutton.dart
+++ b/lib/src/gbutton.dart
@@ -33,6 +33,8 @@ class GButton extends StatefulWidget {
   final String? semanticLabel;
   final GnavStyle? style;
   final double? textSize;
+  final Size? size;
+
 
   const GButton({
     Key? key,
@@ -64,6 +66,7 @@ class GButton extends StatefulWidget {
     this.semanticLabel,
     this.style = GnavStyle.google,
     this.textSize,
+    this.size
   }) : super(key: key);
 
   @override
@@ -75,40 +78,44 @@ class _GButtonState extends State<GButton> {
   Widget build(BuildContext context) {
     return Semantics(
       label: widget.semanticLabel ?? widget.text,
-      child: Button(
-        textSize: widget.textSize,
-        style: widget.style,
-        borderRadius: widget.borderRadius,
-        border: widget.border,
-        activeBorder: widget.activeBorder,
-        shadow: widget.shadow,
-        debug: widget.debug,
-        duration: widget.duration,
-        iconSize: widget.iconSize,
-        active: widget.active,
-        onPressed: () {
-          if (widget.haptic!) HapticFeedback.selectionClick();
-          widget.onPressed?.call();
-        },
-        padding: widget.padding,
-        margin: widget.margin,
-        gap: widget.gap,
-        color: widget.backgroundColor,
-        rippleColor: widget.rippleColor,
-        hoverColor: widget.hoverColor,
-        gradient: widget.backgroundGradient,
-        curve: widget.curve,
-        leading: widget.leading,
-        iconActiveColor: widget.iconActiveColor,
-        iconColor: widget.iconColor,
-        icon: widget.icon,
-        text: Text(
-          widget.text,
-          style: widget.textStyle ??
-              TextStyle(
-                fontWeight: FontWeight.w600,
-                color: widget.textColor,
-              ),
+      child: SizedBox(
+        width: widget.size != null ? widget.size!.width : null,
+        height: widget.size != null ? widget.size!.height : null,
+        child: Button(        
+          textSize: widget.textSize,
+          style: widget.style,
+          borderRadius: widget.borderRadius,
+          border: widget.border,
+          activeBorder: widget.activeBorder,
+          shadow: widget.shadow,
+          debug: widget.debug,
+          duration: widget.duration,
+          iconSize: widget.iconSize,
+          active: widget.active,
+          onPressed: () {
+            if (widget.haptic!) HapticFeedback.selectionClick();
+            widget.onPressed?.call();
+          },
+          padding: widget.padding,
+          margin: widget.margin,
+          gap: widget.gap,
+          color: widget.backgroundColor,
+          rippleColor: widget.rippleColor,
+          hoverColor: widget.hoverColor,
+          gradient: widget.backgroundGradient,
+          curve: widget.curve,
+          leading: widget.leading,
+          iconActiveColor: widget.iconActiveColor,
+          iconColor: widget.iconColor,
+          icon: widget.icon,
+          text: Text(
+            widget.text,
+            style: widget.textStyle ??
+                TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: widget.textColor,
+                ),
+          ),
         ),
       ),
     );

--- a/lib/src/gnav.dart
+++ b/lib/src/gnav.dart
@@ -36,6 +36,7 @@ class GNav extends StatefulWidget {
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
     this.style = GnavStyle.google,
     this.textSize,
+    this.selectedGbuttonSize
   }) : super(key: key);
 
   final List<GButton> tabs;
@@ -64,6 +65,7 @@ class GNav extends StatefulWidget {
   final MainAxisAlignment mainAxisAlignment;
   final GnavStyle? style;
   final double? textSize;
+  final Size? selectedGbuttonSize;
 
   @override
   _GNavState createState() => _GNavState();
@@ -94,7 +96,7 @@ class _GNavState extends State<GNav> {
         child: Row(
             mainAxisAlignment: widget.mainAxisAlignment,
             children: widget.tabs
-                .map((t) => GButton(
+                .map((t) => GButton(                                            
                       textSize: widget.textSize,
                       style: widget.style,
                       key: t.key,
@@ -127,17 +129,18 @@ class _GNavState extends State<GNav> {
                       backgroundColor:
                           t.backgroundColor ?? widget.tabBackgroundColor,
                       duration: widget.duration,
+                      size: selectedIndex == widget.tabs.indexOf(t) ? widget.selectedGbuttonSize : null ,
                       onPressed: () {
                         if (!clickable) return;
                         setState(() {
                           selectedIndex = widget.tabs.indexOf(t);
                           clickable = false;
                         });
-
+                
                         t.onPressed?.call();
-
+                
                         widget.onTabChange?.call(selectedIndex);
-
+                
                         Future.delayed(widget.duration, () {
                           if (context.mounted) {
                             setState(() {


### PR DESCRIPTION
## Add custom size for selected `GButton`, solving issue #93 

### Example:

https://github.com/user-attachments/assets/d825cbc8-120b-4eec-87fe-486f2c2eb22c

### Implementation

Set the property `selectedGbuttonSize` with a `Size`.

### Code Example

```dart

GNav(
  rippleColor: Colors.grey[300]!,
  hoverColor: Colors.grey[100]!,
  gap: 8,
  activeColor: Colors.black,
  iconSize: 24,
  padding: EdgeInsets.symmetric(horizontal: 20, vertical: 12),
  duration: Duration(milliseconds: 400),
  tabBackgroundColor: Colors.grey[100]!,
  color: Colors.black,
  selectedGbuttonSize: Size(500, 50), // <----- Here
  tabs: [
    GButton(
      icon: LineIcons.home,
      text: 'Home',
    ),
    GButton(
      icon: LineIcons.heart,
      text: 'Likes',
    ),
    GButton(
      icon: LineIcons.search,
      text: 'Search',
    ),
    GButton(
      icon: LineIcons.user,
      text: 'Profile',
    ),
  ],
  selectedIndex: _selectedIndex,
  onTabChange: (index) {
    setState(() {
      _selectedIndex = index;
    });
  },
)

```

Closes #93 